### PR TITLE
Odd Behaviour When No Matching Remotes

### DIFF
--- a/gituser
+++ b/gituser
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl
+#!/usr/bin/env -S perl -w
 
 # MIT Licence
 #
@@ -92,7 +92,7 @@ no warnings qw(experimental::signatures);
 use File::HomeDir;
 use Path::Class;
 use Path::Class::Iterator;
-use Config::GitLike 1.18;	# https://github.com/bestpractical/config-gitlike/pull/14
+use Config::GitLike 1.18;       # https://github.com/bestpractical/config-gitlike/pull/14
 use Config::GitLike::Git;
 use Text::TabularDisplay;
 use IO::Prompter;
@@ -109,16 +109,16 @@ if ((defined($id_dir_env)) && ($id_dir_env ne '')) {
 else {
     $id_dir = Path::Class::Dir->new(File::HomeDir->my_home, ".git", "id");
 }
-my $it = Path::Class::Iterator->new(
+my $iter = Path::Class::Iterator->new(
     root            => $id_dir,
     follow_symlinks => 1,
     follow_hidden   => 0,
     breadth_first   => 1,
     show_warnings   => 1
     );
-if (defined($it)) {
-    while (not $it->done) {
-        my $file = $it->next;
+if (defined($iter)) {
+    while (not $iter->done) {
+        my $file = $iter->next;
         $identities{$file->basename} = $file->stringify;
     }
 } else {
@@ -135,9 +135,36 @@ unless ($config->is_git_dir(".")) {
     exit;
 }
 $config->load(".");
-my %remotes = $config->get_regexp(
+my %remotes_raw = $config->get_regexp(
     key => 'remote\.[^.]+\.url'
     );
+
+###
+#  parse the remote info into something more palatable
+#
+my %remotes;
+while(my($k, $v) = each %remotes_raw) {
+    my($remote_name) = $k =~ /remote\.([^.]+)\.url/;
+    my($scheme, $authority, $path, $query, $fragment) =
+        $v =~ m|(?:([^:/?#]+):)?(?://([^/?#]*))?([^?#]*)(?:\?([^#]*))?(?:#(.*))?|;
+    if ($scheme =~ /.+@.+/) {
+        # format (4) special case: implicit ssh; extract authority value from scheme
+        ($authority) = $scheme =~ m/.+@(.+)/;
+    }
+    elsif ($authority =~ /.+@.+/) {
+        # formats (1) and (2) special case: remove user part from authority
+        ($authority) = $authority =~ m/.+@(.+)/;
+    }
+    my ($user) = $path =~ m|^/?([^/]+)/.+?$|;
+    if ( ! ($path =~ m|^/.+$|)) {
+        $path = "/$path";
+    }
+    $remotes{$remote_name} = {
+        user => $user,
+        authority => $authority,
+        path => $path,
+    };
+}
 
 ###
 #  if the repo has any remotes configured, pick out those for which we
@@ -156,87 +183,77 @@ if ($num_remotes == 0) {
     my %matching_remotes;
     keys %remotes; # reset the internal iterator so a prior each() doesn't affect the loop
     while(my($k, $v) = each %remotes) {
-        my($remote_name) = $k =~ /remote\.([^.]+)\.url/;
-        my($scheme, $authority, $path, $query, $fragment) =
-            $v =~ m|(?:([^:/?#]+):)?(?://([^/?#]*))?([^?#]*)(?:\?([^#]*))?(?:#(.*))?|;
-        if ($scheme =~ /.+@.+/) {
-            # format (4) special case: implicit ssh; extract authority value from scheme
-            ($authority) = $scheme =~ m/.+@(.+)/;
-        }
-        elsif ($authority =~ /.+@.+/) {
-            # formats (1) and (2) special case: remove user part from authority
-            ($authority) = $authority =~ m/.+@(.+)/;
-        }
-        my ($user) = $path =~ m|^/?([^/]+)/.+?$|;
-	if ( ! ($path =~ m|^/.+$|)) {
-	    $path = "/$path";
-	}
-
         keys %identities; # reset the internal iterator so a prior each() doesn't affect the loop
         while(my($ik, $iv) = each %identities) {
-            if ($ik =~ m/$authority/) {
+            if ($ik =~ m|$v->{'authority'}|) {
                 if (! defined($matching_ids{$ik})) {
-		    $matching_ids{$ik} = { user_match => 0,
-		    			   origin_match => 0, };
+                    $matching_ids{$ik} = { user_match => 0,
+                                           origin_match => 0, };
                 }
-		if ($ik =~ m|$user|) {
-		    $matching_ids{$ik}->{'user_match'} = 1;
-		}
-		if ($remote_name eq 'origin') {
-		    $matching_ids{$ik}->{'origin_match'} = 1;
-		}
-                if (! defined($matching_remotes{$remote_name})) {
-                    $matching_remotes{$remote_name} = {
-			forge => $authority,
-			path  => $path,
-		    };
+                if ($ik =~ m|$v->{'user'}|) {
+                    $matching_ids{$ik}->{'user_match'} = 1;
+                }
+                if ($k eq 'origin') {
+                    $matching_ids{$ik}->{'origin_match'} = 1;
+                }
+                if (! defined($matching_remotes{$k})) {
+                    $matching_remotes{$k} = {
+                        forge => $v->{authority},
+                        path  => $v->{path},
+                    };
                 }
             }
         }
     }
 
     my $remote_count = keys %matching_remotes;
-    print "This repo has $remote_count remote".(($remote_count > 1)?'s':'')." on forges for which you have a user ID:\n";
-    my $table_remotes = Text::TabularDisplay->new( ('remote', 'forge repo',) );
-    keys %matching_remotes; # reset the internal iterator so a prior each() doesn't affect the loop
-    while (my($rid, $rinf) = each %matching_remotes) {
-        $table_remotes->add( ($rid,
-			      $rinf->{'forge'}.$rinf->{'path'}) );
-    }
-    print $table_remotes->render."\n";
+    print "This repo has $remote_count remote".(($remote_count != 1)?'s':'')." on forges for which you have a user ID".(($remote_count > 0)?':':'.')."\n";
+    if ($remote_count > 0) {
+        my $table_remotes = Text::TabularDisplay->new( ('remote', 'forge repo',) );
+        keys %matching_remotes; # reset the internal iterator so a prior each() doesn't affect the loop
+        while (my($rid, $rinf) = each %matching_remotes) {
+            $table_remotes->add( ($rid,
+                                  $rinf->{'forge'}.$rinf->{'path'}) );
+        }
+        print $table_remotes->render."\n";
 
-    my $id_count = keys %matching_ids;
-    print "These are your identit".(($id_count > 1)?'ies':'y')." for these forges:\n";
-    my @id_names;
-    my $origin_id;
-    my $table_ids = Text::TabularDisplay->new( ('ID',) );
-    keys %matching_ids; # reset the internal iterator so a prior each() doesn't affect the loop
-    while (my($id, $inf) = each %matching_ids) {
-        $table_ids->add( ($id,) );
-        push  @id_names, $id;
-	if ($inf->{'user_match'} && $inf->{'origin_match'}) {
-	    $origin_id = $id;
-	}
-    }
-    print $table_ids->render."\n";
+        my $id_count = keys %matching_ids;
+        print "Th".(($id_count != 1)?'ese are':'is is')." your identit".(($id_count != 1)?'ies':'y')." for these forges:\n";
+        my @id_names;
+        my $origin_id;
+        my $table_ids = Text::TabularDisplay->new( ('ID',) );
+        keys %matching_ids; # reset the internal iterator so a prior each() doesn't affect the loop
+        while (my($id, $inf) = each %matching_ids) {
+            $table_ids->add( ($id,) );
+            push  @id_names, $id;
+            if ($inf->{'user_match'} && $inf->{'origin_match'}) {
+                $origin_id = $id;
+            }
+        }
+        print $table_ids->render."\n";
 
-    my $prompt = 'ID for future commits (TAB completes/cycles)';
-    my $selection;
-    if (defined($origin_id)) {
-      # there is a remote called 'origin'; prompt with origin as the default
-      $selection
-          = prompt "$prompt [$origin_id]",
-          -guar=>\@id_names,
-          -def=>$origin_id,
-          ':';
-    } else {
-        # no remote called 'origin'; prompt without default
-        $selection
-            = prompt $prompt,
-            -guar=>\@id_names,
-            ':';
+        my $prompt = 'ID for future commits (TAB completes/cycles)';
+        my $selection;
+        if (defined($origin_id)) {
+            # there is a remote called 'origin'; prompt with origin as the default
+            $selection
+                = prompt "$prompt [$origin_id]",
+                -guar=>\@id_names,
+                -def=>$origin_id,
+                ':';
+        } else {
+            # no remote called 'origin'; prompt without default
+            $selection
+                = prompt $prompt,
+                -guar=>\@id_names,
+                ':';
+        }
+        $id_file = $identities{$selection};
     }
-    $id_file = $identities{$selection};
+    else {
+        print "Using local id from $identities{'local'}.\n";
+        $id_file = $identities{'local'};
+    }
 }
 print "Setting git user id from $id_file\n";
 my $user_data = Config::GitLike->load_file($id_file);


### PR DESCRIPTION
Previously, when there was no matching remote, an empty table was
presented, and the user was prompted to choose an ID. This doesn't
make sense, as there is nothing to choose.

Now, in this case, no table or choice are presented, and the local ID
is used instead.