### PR TITLE
Troublesome Default Identities Directory Name

### DIFF
--- a/gituser
+++ b/gituser
@@ -133,7 +133,7 @@ sub load_identities () {
   if ((defined($id_dir_env)) && ($id_dir_env ne '')) {
     $id_dir = Path::Class::Dir->new($id_dir_env);
   } else {
-    $id_dir = Path::Class::Dir->new(File::HomeDir->my_home, ".git", "id");
+    $id_dir = Path::Class::Dir->new(File::HomeDir->my_home, ".gitids");
   }
   my $iter = Path::Class::Iterator->new(
 					root            => $id_dir,


### PR DESCRIPTION
The default name of "~/.git/id" was fairly unfortunate, since the
presence of a ".git" directory (despite it NOT containing any "config"
file) tricks many tools into thinking the home directory was a
repository or working copy.

This commit changes the name of the default identities directory to a
less controversial "~/.gitids".